### PR TITLE
fix: correcting the RabbitMqCustomResource bundling setup

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -99,7 +99,7 @@
       "description": "Create a JavaScript bundle from src/rabbitmq/custom-resource/handler/index.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/rabbitmq/custom-resource/handler/index.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/rabbitmq/custom-resource/handler/index/index.js\" --external:@aws-sdk/*"
+          "exec": "esbuild --bundle src/rabbitmq/custom-resource/handler/index.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/rabbitmq/custom-resource/handler/index/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:@aws-sdk/*"
         }
       ]
     },
@@ -108,7 +108,7 @@
       "description": "Continuously update the JavaScript bundle from src/rabbitmq/custom-resource/handler/index.ts",
       "steps": [
         {
-          "exec": "esbuild --bundle src/rabbitmq/custom-resource/handler/index.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/rabbitmq/custom-resource/handler/index/index.js\" --external:@aws-sdk/* --watch"
+          "exec": "esbuild --bundle src/rabbitmq/custom-resource/handler/index.ts --target=\"node18\" --platform=\"node\" --outfile=\"assets/rabbitmq/custom-resource/handler/index/index.js\" --tsconfig=\"tsconfig.dev.json\" --external:@aws-sdk/* --watch"
         }
       ]
     },

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -51,6 +51,7 @@ project.bundler.addBundle('src/rabbitmq/custom-resource/handler/index.ts', {
   externals: [
     '@aws-sdk/*',
   ],
+  tsconfigPath: 'tsconfig.dev.json',
 });
 
 project.eslint?.allowDevDeps('src/rabbitmq/custom-resource/handler/dynamic-references/secret.ts');

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# AWS::AmazonMQ L2 Construct Library
+# AWS::AmazonMQ L2+ Construct Library
 
 <!--BEGIN STABILITY BANNER-->
 

--- a/test/integ/rabbitmq-broker-custom-resource.integ.snapshot/RabbitMqBrokerCustomResourceTest.assets.json
+++ b/test/integ/rabbitmq-broker-custom-resource.integ.snapshot/RabbitMqBrokerCustomResourceTest.assets.json
@@ -1,20 +1,20 @@
 {
   "version": "38.0.1",
   "files": {
-    "401753df90db62ffd49ad746479622f8ef095ec408f0bb5f21b41ea52ac85963": {
+    "d45bf79c36d36bde5dca5a314c3d2d7c5dca878c01617d0c40303bc97b9c300c": {
       "source": {
-        "path": "asset.401753df90db62ffd49ad746479622f8ef095ec408f0bb5f21b41ea52ac85963",
+        "path": "asset.d45bf79c36d36bde5dca5a314c3d2d7c5dca878c01617d0c40303bc97b9c300c",
         "packaging": "zip"
       },
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "401753df90db62ffd49ad746479622f8ef095ec408f0bb5f21b41ea52ac85963.zip",
+          "objectKey": "d45bf79c36d36bde5dca5a314c3d2d7c5dca878c01617d0c40303bc97b9c300c.zip",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }
     },
-    "3effaad3f4e52807a05385096d4a81ee1f6e0a5969898987133a538955118db5": {
+    "8b82d23ce067d7e52e1f93af52d5b454eb3cff1998bfbbd87b4dd2cd3172b7ca": {
       "source": {
         "path": "RabbitMqBrokerCustomResourceTest.template.json",
         "packaging": "file"
@@ -22,7 +22,7 @@
       "destinations": {
         "current_account-current_region": {
           "bucketName": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}",
-          "objectKey": "3effaad3f4e52807a05385096d4a81ee1f6e0a5969898987133a538955118db5.json",
+          "objectKey": "8b82d23ce067d7e52e1f93af52d5b454eb3cff1998bfbbd87b4dd2cd3172b7ca.json",
           "assumeRoleArn": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/cdk-hnb659fds-file-publishing-role-${AWS::AccountId}-${AWS::Region}"
         }
       }

--- a/test/integ/rabbitmq-broker-custom-resource.integ.snapshot/RabbitMqBrokerCustomResourceTest.template.json
+++ b/test/integ/rabbitmq-broker-custom-resource.integ.snapshot/RabbitMqBrokerCustomResourceTest.template.json
@@ -223,7 +223,7 @@
      "S3Bucket": {
       "Fn::Sub": "cdk-hnb659fds-assets-${AWS::AccountId}-${AWS::Region}"
      },
-     "S3Key": "401753df90db62ffd49ad746479622f8ef095ec408f0bb5f21b41ea52ac85963.zip"
+     "S3Key": "d45bf79c36d36bde5dca5a314c3d2d7c5dca878c01617d0c40303bc97b9c300c.zip"
     },
     "Description": "src/rabbitmq/custom-resource/handler/rabbit-mq-api-call.lambda/index.ts",
     "Handler": "index.handler",


### PR DESCRIPTION
Adds `"use strict";` preamble in the `RabbitMqCustomResource` bundled function.